### PR TITLE
fix the datadir path in windows

### DIFF
--- a/zk/server_help.go
+++ b/zk/server_help.go
@@ -45,10 +45,23 @@ func StartTestCluster(size int, stdout, stderr io.Writer) (*TestCluster, error) 
 			return nil, err
 		}
 		port := startPort + serverN*3
+
+		// Convert windows style path to posix style path
+		// to avoid that java zookeeper server omits the
+		// backslash in dataDir when loading cfg.
+		// For example, java zookeeper server will transfer
+		//     C:\Users\AppData\Local\Temp
+		// to
+		//     C:UsersAppDataLocalTemp
+		// So we should use
+		//     C:/Users/AppData/Local/Temp
+		// to avoid this.
+		dataDir := filepath.ToSlash(srvPath)
 		cfg := ServerConfig{
 			ClientPort: port,
-			DataDir:    srvPath,
+			DataDir:    dataDir,
 		}
+
 		for i := 0; i < size; i++ {
 			cfg.Servers = append(cfg.Servers, ServerConfigServer{
 				ID:                 i + 1,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:

Fix the datadir path in windows.

**Special notes for your reviewer**:

- Because windows uses the backslash (`\`) as the path seperator, so in cfg, the default dataDir will like `C:\Users\AppData\Local\Temp`. 
- However java zookeeper server will omit the backslash when loading cfg, so
the dataDir will be transfered to `C:UsersAppDataLocalTemp`.
- Finally server will make a data dir (and data log dir) like this:
<img width="707" alt="1" src="https://user-images.githubusercontent.com/16648345/86206125-29478000-bb9e-11ea-8821-3a3aacaeb2c4.png">

