### PR TITLE
fix the bug that Zk restarts can cause deadlocks

### DIFF
--- a/zk/conn.go
+++ b/zk/conn.go
@@ -971,7 +971,30 @@ func (c *Conn) queueRequest(opcode int32, req interface{}, res interface{}, recv
 		recvChan:   make(chan response, 1),
 		recvFunc:   recvFunc,
 	}
-	c.sendChan <- rq
+
+	switch opcode {
+	case opClose:
+		select {
+		case c.sendChan <- rq:
+		case <-time.After(c.connectTimeout * 2):
+			c.logger.Printf("gave up trying to send opClose to server")
+			rq.recvChan <- response{-1, ErrConnectionClosed}
+		}
+	default:
+		// otherwise avoid deadlocks for dumb clients who aren't aware that
+		// the ZK connection is closed yet.
+		select {
+		case <-c.shouldQuit:
+			rq.recvChan <- response{-1, ErrConnectionClosed}
+		case c.sendChan <- rq:
+			select {
+			case <-c.shouldQuit:
+				// maybe the caller gets this, maybe not- we tried.
+				rq.recvChan <- response{-1, ErrConnectionClosed}
+			default:
+			}
+		}
+	}
 	return rq.recvChan
 }
 


### PR DESCRIPTION
**What this PR does**:
fix the bug that Zk restarts can cause deadlocks

**Which issue(s) this PR fixes**:
https://github.com/apache/dubbo-go/issues/810
Fixes #
