### PR TITLE
修复request可能发生阻塞

### DIFF
--- a/zk/conn.go
+++ b/zk/conn.go
@@ -980,7 +980,7 @@ func (c *Conn) queueRequest(opcode int32, req interface{}, res interface{}, recv
 		ret = response{-1, ErrConnectionClosed}
 	case <-time.After(c.connectTimeout * 2):
 		c.logger.Printf("request of conn is timeout, xid:(%d)", rq.xid)
-		ret = response{-1, ErrConnectionClosed}
+		ret = response{-1, ErrResponse}
 	}
 	retChan := make(chan response, 1)
 	retChan <- ret

--- a/zk/conn.go
+++ b/zk/conn.go
@@ -971,7 +971,12 @@ func (c *Conn) queueRequest(opcode int32, req interface{}, res interface{}, recv
 		recvChan:   make(chan response, 1),
 		recvFunc:   recvFunc,
 	}
-	c.sendChan <- rq
+
+	select {
+	case c.sendChan <- rq:
+	case <-time.After(c.connectTimeout * 2):
+		c.logger.Printf("send request timeout, xid:(%d)", rq.xid)
+	}
 
 	ret := response{}
 	select {

--- a/zk/conn.go
+++ b/zk/conn.go
@@ -979,6 +979,7 @@ func (c *Conn) queueRequest(opcode int32, req interface{}, res interface{}, recv
 	case <-c.shouldQuit:
 		ret = response{-1, ErrConnectionClosed}
 	case <-time.After(c.connectTimeout * 2):
+		c.logger.Printf("request of conn is timeout, xid:(%d)", rq.xid)
 		ret = response{-1, ErrConnectionClosed}
 	}
 	retChan := make(chan response, 1)

--- a/zk/conn.go
+++ b/zk/conn.go
@@ -971,7 +971,7 @@ func (c *Conn) queueRequest(opcode int32, req interface{}, res interface{}, recv
 		recvChan:   make(chan response, 1),
 		recvFunc:   recvFunc,
 	}
-	go func() { c.sendChan <- rq }()
+	c.sendChan <- rq
 
 	ret := response{}
 	select {

--- a/zk/constants.go
+++ b/zk/constants.go
@@ -113,6 +113,7 @@ var (
 	ErrClosing                 = errors.New("zk: zookeeper is closing")
 	ErrNothing                 = errors.New("zk: no server responsees to process")
 	ErrSessionMoved            = errors.New("zk: session moved to another server, so operation is ignored")
+	ErrResponse                = errors.New("zk: response timeout")
 
 	// ErrInvalidCallback         = errors.New("zk: invalid callback specified")
 	errCodeToError = map[ErrCode]error{


### PR DESCRIPTION
由于网络波动或者其他原因，不能完全相信每个request都会有对应的response，所以这个地方要加上超时时间，否则会概率性阻塞